### PR TITLE
make optional the keeping of whitespace before point on save

### DIFF
--- a/ws-butler.el
+++ b/ws-butler.el
@@ -158,9 +158,10 @@ replaced by spaces.
 (defun ws-butler-before-save ()
   "Trim white space before save.
 
-This will also ensure point doesn't jump due to white space
-trimming.  (i.e. keep whitespace after EOL text but before
-point, if enabled."
+If `ws-butler-keep-whitespace-before-point' is set,
+this will also ensure point doesn't jump due to white space
+trimming (i.e. keep whitespace after EOL text but before
+point)."
   ;; save data to restore later
   (ws-butler-with-save
    (widen)


### PR DESCRIPTION
This adds a new variable that enables/disables the current feature that keeps whitespace before point on save, but the default is "t" (true), so default behavior remains the same as before. A user can set it to "nil" to disable the feature.
