### PR TITLE
Give user option to skip stripping of whitespace on specific regions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,15 @@ By default, ws-butler preserves "virtual spaces" in front of point if necessary.
 
 This can be disabled with `ws-butler-keep-whitespace-before-point`.
 
+#### Trimming only specific lines.
+
+There might be lines you don't want to get trimmed, e.g. spaces in multiline strings.  The behavior can be customized through `ws-butler-trim-predicate`.  This variable should hold a function that expects 2 arguments (region beginning and end) and should return true only for regions that one wants to get trimmed. As an example
+
+    (setq ws-butler-trim-predicate
+          (lambda (beg end)
+            (not (eq 'font-lock-string-face
+                     (get-text-property end 'face)))))
+
 ## History
 
 1. I started by trimming all spaces at EOL in source code in a

--- a/tests/ws-butler-tests.el
+++ b/tests/ws-butler-tests.el
@@ -5,6 +5,7 @@
 
 ;; for "every" function
 (require 'cl)
+(load-file "ws-butler.el")
 
 (defmacro ws-butler-test-with-test-buffer (&rest body)
   (declare (indent 0) (debug t))
@@ -28,3 +29,16 @@
     (execute-kbd-macro (read-kbd-macro "M-DEL"))
     (should (every #'identity (list 1 2 3)))
     (should (string-equal (buffer-string) "a b "))))
+
+(ert-deftest ws-butler-test-trim-predicate ()
+  "Tests `ws-butler-trim-predicate'."
+  (ws-butler-test-with-common-setup
+   (let ((ws-butler-trim-predicate (lambda (_beg _end) false)))
+     (insert "a b c. \n")
+     (ws-butler-before-save)
+     (should (string-equal (buffer-string) "a b c. \n")))
+   (let (ws-butler-trim-predicate)
+     (erase-buffer)
+     (insert "a b c. \n")
+     (ws-butler-before-save)
+     (should (string-equal (buffer-string) "a b c.\n")))))

--- a/ws-butler.el
+++ b/ws-butler.el
@@ -71,6 +71,16 @@ i.e. only the \"virtual\" space is preserved in the buffer."
   :type 'boolean
   :group 'ws-butler)
 
+(defcustom ws-butler-trim-predicate
+  nil
+  "Return true for regions that should be trimmed.
+
+Expects 2 arguments - beginning and end of a region.
+Should return a truthy value for regions that should
+have their trailing whitespace trimmed.
+When not defined all regions are trimmed."
+  :type 'function
+  :group 'ws-butler)
 
 (defvar ws-butler-saved)
 
@@ -200,7 +210,9 @@ ensure point doesn't jump due to white space trimming."
                ;; always expand to end of line anyway, this should be OK.
                end (progn (goto-char (1- end))
                           (point-at-eol))))
-       (ws-butler-clean-region beg end)
+       (unless (and (functionp ws-butler-trim-predicate)
+                    (not (funcall ws-butler-trim-predicate beg end)))
+         (ws-butler-clean-region beg end))
        (setq last-end end)))
     (ws-butler-maybe-trim-eob-lines last-end)))
 


### PR DESCRIPTION
When writing Elixir code I hit into a little unwanted functionality. Elixir has multiline, heredoc-style strings, e.g.

```
"""
This is 
a multiline 
string
"""
```

Trailing whitespace inside this is part of the string, so when stripping it one is effectively changing the string the user put in.

I took the liberty to create this PR in order to provide a quick solution to this. The code checks if the end of line is font-locked as doc or string and if so skips it. This fixed my current issue. If you feel like this is a good-enough solution consider accepting the PR. If not feel free to let me know of any changes I should make to get this accepted or write a different solution if this one is stupid (I'm not an emacs expert).

Thank you for your time in advance.