### PR TITLE
Add subsection on basic config in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,17 @@ There might be lines you don't want to get trimmed, e.g. spaces in multiline str
 
 `apt-get install elpa-ws-butler`
 
+### Configuration
+
+To use ws-butler, require it and add ws-butler-mode as a hook on any mode
+where you would like it to be enabled. For example, to enable for all 
+ruby-mode buffers, add this to your .emacs:
+
+    (require 'ws-butler)
+    (add-hook 'ruby-mode-hook #'ws-butler-mode)
+
+Alternatively, you can use ws-butler-global-mode to turn it on everywhere.
+
 ## History
 
 1. I started by trimming all spaces at EOL in source code in a

--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@ There might be lines you don't want to get trimmed, e.g. spaces in multiline str
 
 To use ws-butler, require it and add ws-butler-mode as a hook on any mode
 where you would like it to be enabled. For example, to enable for all 
-ruby-mode buffers, add this to your .emacs:
+programming language modes, add this to your .emacs:
 
     (require 'ws-butler)
-    (add-hook 'ruby-mode-hook #'ws-butler-mode)
+    (add-hook 'prog-mode-hook #'ws-butler-mode)
 
 Alternatively, you can use ws-butler-global-mode to turn it on everywhere.
 


### PR DESCRIPTION
Make it obvious, for new users, what minimal steps you need to start using ws-butler. 
Adapts and expands (a little) on the installation notes given at the top of ws-butler.el.