### PR TITLE
Inhibit modification hooks in ws-butler-after-save

### DIFF
--- a/ws-butler.el
+++ b/ws-butler.el
@@ -279,15 +279,15 @@ ensure point doesn't jump due to white space trimming."
   (ws-butler-clear-properties)
   ;; go to saved line+col
   (when ws-butler-presave-coord
-    (let (remaining-lines)
-      (ws-butler-with-save
-       (widen)
-       (goto-char (point-min))
-       (setq remaining-lines (forward-line (1- (car ws-butler-presave-coord)))))
-      (unless (eq remaining-lines 0)
-        (insert (make-string remaining-lines ?\n))))
-    (move-to-column (cadr ws-butler-presave-coord) t)
-    (set-buffer-modified-p nil)))
+    (with-silent-modifications
+      (let (remaining-lines)
+        (ws-butler-with-save
+         (widen)
+         (goto-char (point-min))
+         (setq remaining-lines (forward-line (1- (car ws-butler-presave-coord)))))
+        (unless (eq remaining-lines 0)
+          (insert (make-string remaining-lines ?\n))))
+      (move-to-column (cadr ws-butler-presave-coord) t))))
 
 (defun ws-butler-before-revert ()
   "Clear `ws-butler-presave-coord'."


### PR DESCRIPTION
This PR sets out to fix https://github.com/seagle0128/doom-modeline/issues/129.

**What this PR does:** it inhibits modification hooks while ws-butler-after-save restores virtual whitespace to the buffer post-save.

**Rationale:**
* The doom-modeline package uses a hook in `after-save-hook` and `after-change-functions` to update a buffer-modified indicator in the mode line.
* The `insert` and forced `move-to-column` calls in `ws-butler-after-save` trigger `after-change-functions` when writing virtual whitespace into the buffer (causing doom-modeline to indicate the buffer has changed).
* There is no mechanism through which doom-modeline can subscribe to changes in the buffer's modified status besides `after-save-hook`, so the subsequent call to `(set-buffer-modified-p nil)` will not reach doom-modeline.
* Since `ws-butler-after-save` is appended to `after-save-hook` buffer-locally, the only way for doom-modeline to sneak a update hook into it by making users aware of the race condition, or accommodating ws-butler specifically.

Thus, doom-modeline incorrectly reports a modified buffer when it isn't modified.

It's debatable whether doom-modeline or ws-butler should adapt, but I didn't think insertion of virtual whitespace should trigger modfiication hooks in the first place, so here I am!