### PR TITLE
Add support to ppc64le. Install emacs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,24 @@
 language: emacs-lisp
+arch:
+  - amd64
+  - ppc64le
+jobs:
+  exclude:
+   - arch: ppc64le   
+     env: EMACS=emacs-snapshot
 before_install:
   - git submodule update --init
+  - if [ "$TRAVIS_CPU_ARCH" = 'ppc64le' ]; then
+      sudo apt-get update && 
+      sudo apt-get install -y emacs;
+    fi
   - if [ "$EMACS" = 'emacs-snapshot' ]; then
       sudo add-apt-repository -y ppa:cassou/emacs &&
       sudo apt-get update --allow-unauthenticated -qq &&
       sudo apt-get install -qq
           emacs-snapshot-el emacs-snapshot-gtk emacs-snapshot;
     fi
+ 
 env:
   - EMACS=emacs
   - EMACS=emacs-snapshot


### PR DESCRIPTION
This PR adds CI support for "linux on power architecture".  Project is part of ubuntu dist on this platform as well. The change will help in continuously building and testing on this platform so that any issues can be detected and fixed earlier so that we are always upto-date. 
PS: Since emacs-snapshot related pkg not available, disabled it for ppc64le