### PR TITLE
Add NonGNU ELPA badge to README.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/lewang/ws-butler.png)](http://travis-ci.org/lewang/ws-butler)
+[![NonGNU ELPA](https://elpa.nongnu.org/nongnu/ws-butler.svg)](https://elpa.nongnu.org/nongnu/ws-butler.html)
 
 ## ws-butler -- an unobtrusive way to trim spaces from end of line
 


### PR DESCRIPTION
Hi!

We have now added this package to [NonGNU ELPA](http://elpa.nongnu.org/nongnu/ws-butler.html), a new package repository that will be enabled by default in Emacs 28. This means that users will be able to install this package without any further configuration needed on their part: they can just run `M-x list-packages` and install it out of the box.

The main difference between NonGNU ELPA and MELPA is that only tagged versions of packages are released. This means that a new release will only be packaged when you bump the "Version" header. You are free to bump the package version (thereby releasing a new version) whenever you think it makes sense to release a new version to users of NonGNU ELPA.

This commit adds a badge, because it looks nice and is occasionally useful.

Please let me know if you have any questions about any of this.

Thanks!

PS. I see some rendering issues with the README on the package page; I am looking into how we can improve the display.