### PR TITLE
fix: line-end-position -> line-beginning-position

### DIFF
--- a/ws-butler.el
+++ b/ws-butler.el
@@ -248,7 +248,7 @@ ensure point doesn't jump due to white space trimming."
      (lambda (_prop beg end)
        (save-excursion
          (setq beg (progn (goto-char beg)
-                          (line-end-position))
+                          (line-beginning-position))
                ;; Subtract one from end to overcome Emacs bug #17784, since we
                ;; always expand to end of line anyway, this should be OK.
                end (progn (goto-char (1- end))


### PR DESCRIPTION
In commit cbb0406, a use of `point-at-bol` was changed to `line-end-position`. However, `point-at-bol` is an alias for `line-beginning-position`, not `line-end-position`. This change has caused ws-butler to stop cleaning up whitespace on save for me.