### PR TITLE
Exempt message-mode

### DIFF
--- a/ws-butler.el
+++ b/ws-butler.el
@@ -98,6 +98,7 @@ changed in this specific way."
     term-mode
     eshell-mode
     diff-mode
+    message-mode
     markdown-mode)
   "Don't enable ws-butler in modes that inherit from these.
 


### PR DESCRIPTION
Emails can contain whitespace-sensitive patches. The standard signature separator and format=flowed also use trailing whitespace.