### PR TITLE
Fixup erroneous refactoring

### DIFF
--- a/ws-butler.el
+++ b/ws-butler.el
@@ -248,7 +248,7 @@ ensure point doesn't jump due to white space trimming."
      (lambda (_prop beg end)
        (save-excursion
          (setq beg (progn (goto-char beg)
-                          (line-end-position))
+                          (line-beginning-position))
                ;; Subtract one from end to overcome Emacs bug #17784, since we
                ;; always expand to end of line anyway, this should be OK.
                end (progn (goto-char (1- end))


### PR DESCRIPTION
This was `point-at-bol` before #51, which was probably confused with `point-at-eol`.

Without this, ws-butler doesn't actually do anything for me on save.

Also see https://github.com/lewang/ws-butler/pull/51/files#r1874892776