### PR TITLE
Use lexical bindings and misc cleanups

### DIFF
--- a/ws-butler.el
+++ b/ws-butler.el
@@ -318,12 +318,14 @@ for lines modified by you."
     (remove-hook 'after-revert-hook #'ws-butler-after-save t)
     (remove-hook 'edit-server-done-hook #'ws-butler-before-save t)))
 
+(defun ws-butler--turn-on ()
+  "Enable `ws-butler-mode' unless current major mode is exempt."
+  (unless (apply #'derived-mode-p ws-butler-global-exempt-modes)
+    (ws-butler-mode)))
+
 ;;;###autoload
-(define-globalized-minor-mode ws-butler-global-mode ws-butler-mode
-  (lambda ()
-    "Enable `ws-butler-mode' unless current major mode is exempt."
-    (unless (apply #'derived-mode-p ws-butler-global-exempt-modes)
-      (ws-butler-mode))))
+(define-globalized-minor-mode ws-butler-global-mode
+  ws-butler-mode ws-butler--turn-on)
 
 (provide 'ws-butler)
 

--- a/ws-butler.el
+++ b/ws-butler.el
@@ -14,8 +14,9 @@
 ;; Last-Updated:
 ;;           By:
 ;; URL: https://github.com/lewang/ws-butler
-;; Keywords:
+;; Keywords: convenience
 ;; Compatibility: Emacs 24
+;; Package-Requires: ((emacs "24.3"))
 
 ;;; Installation:
 

--- a/ws-butler.el
+++ b/ws-butler.el
@@ -1,4 +1,4 @@
-;;; ws-butler.el --- Unobtrusively remove trailing whitespace.
+;;; ws-butler.el --- Unobtrusively remove trailing whitespace -*- lexical-binding: t -*-
 
 ;; this file is not part of Emacs
 

--- a/ws-butler.el
+++ b/ws-butler.el
@@ -154,7 +154,7 @@ Also see `require-final-newline'."
   (unless buffer-read-only
     (unless last-modified-pos
       (ws-butler-map-changes
-       (lambda (_prop beg end)
+       (lambda (_prop _beg end)
          (setq last-modified-pos end))))
     ;; trim EOF newlines if required
     (when last-modified-pos

--- a/ws-butler.el
+++ b/ws-butler.el
@@ -57,13 +57,6 @@
 (eval-when-compile
   (require 'cl-lib))
 
-(eval-and-compile
-  (unless (fboundp 'setq-local)
-    (defmacro setq-local (var val)
-      "Set variable VAR to value VAL in current buffer."
-      ;; Can't use backquote here, it's too early in the bootstrap.
-      (list 'set (list 'make-local-variable (list 'quote var)) val))))
-
 (defgroup ws-butler nil
   "Unobtrusively whitespace deletion like a butler."
   :group 'convenience)


### PR DESCRIPTION
I wrote this PR primarily to enable lexical bindings so that next time the Emacs devs discuss turning it on by default there will be fewer packages in the wild using dynamic-scoping.

While I was at it, I fixed the rest of the compiler/checkdoc warnings (see the commit messages). I have no special attachment to any of these changes or to this PR so feel free to close it, discard whatever you don't want, etc.